### PR TITLE
Change config format to use a map for jobs instead of a list

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ func main() {
         driver: mysql
 
         jobs:
-          - name: users
+          users:
             columns: [id, name, age]
             source:
               table: users
@@ -40,9 +40,15 @@ func main() {
 
     // Exec all jobs
     results, errs := cfg.ExecAllJobs()
+    userResult := results["users"]
+    userErr := errs["users"]
 
-    // "Ping" all jobs to make sure sources/targets are reachable and tables exist
-    pingResults, err := cfg.Ping(30 * time.Second)
+    // "Ping" a single jobs by name, to make sure sources/targets are reachable and tables exist
+    results, err := config.PingJob(jobName, 30*time.Second)
+
+    // "Ping" all jobs
+    allResults, err := config.PingAllJobs(30 * time.Second)
+    userPingResult := allResults["users"]
 }
 ```
 

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -20,12 +20,14 @@ var execCmd = &cobra.Command{
 		if len(args) == 0 {
 			results, errs := config.ExecAllJobs()
 
-			for i, job := range config.Jobs {
-				if i != 0 {
+			first := true
+			for jobName := range config.Jobs {
+				if !first {
+					first = false
 					fmt.Println() // Add a newline between job results
 				}
 
-				printExecOutput(job.Name, results[i], errs[i])
+				printExecOutput(jobName, results[jobName], errs[jobName])
 			}
 		} else {
 			for i, jobName := range args {

--- a/cmd/ping.go
+++ b/cmd/ping.go
@@ -25,12 +25,14 @@ var pingCmd = &cobra.Command{
 				return
 			}
 
-			for i, job := range config.Jobs {
-				if i != 0 {
+			first := true
+			for jobName := range config.Jobs {
+				if !first {
+					first = false
 					fmt.Println() // Add a newline between job results
 				}
 
-				printPingOutput(job.Name, allResults[i].Tables, nil)
+				printPingOutput(jobName, allResults[jobName], nil)
 			}
 		} else {
 			for i, jobName := range args {
@@ -45,7 +47,7 @@ var pingCmd = &cobra.Command{
 	},
 }
 
-func printPingOutput(jobName string, results []sync.TablePingResult, err error) {
+func printPingOutput(jobName string, results []sync.PingResult, err error) {
 	if err != nil {
 		fmt.Println(err)
 		return

--- a/config.go
+++ b/config.go
@@ -3,7 +3,6 @@ package sync
 import (
 	"fmt"
 	"os"
-	"slices"
 
 	"gopkg.in/yaml.v3"
 )
@@ -12,14 +11,11 @@ import (
 type Config struct {
 	Driver             string
 	CredentialDefaults map[string]CredentialsConfig `yaml:"credentialDefaults"`
-	Jobs               []JobConfig
+	Jobs               map[string]JobConfig
 }
 
 // JobConfig contains the configuration for a single sync job
 type JobConfig struct {
-	// Name uniquely identifies a job
-	Name string
-
 	// Columns defines the columns for the source and target tables
 	Columns []string
 
@@ -99,31 +95,35 @@ func loadConfig(fileContents string) (Config, error) {
 	defaultDriver := config.Driver
 
 	// Impose some default values
-	for i := range config.Jobs {
+	for jobName := range config.Jobs {
+		job := config.Jobs[jobName]
+
 		// For each job, if PrimaryKey is empty, set it to "id"
-		if config.Jobs[i].PrimaryKey == "" && len(config.Jobs[i].PrimaryKeys) == 0 {
-			config.Jobs[i].PrimaryKey = "id"
+		if job.PrimaryKey == "" && len(job.PrimaryKeys) == 0 {
+			job.PrimaryKey = "id"
 		}
 
 		// If PrimaryKey is non-empty, copy it to PrimaryKeys
-		if config.Jobs[i].PrimaryKey != "" {
-			config.Jobs[i].PrimaryKeys = []string{config.Jobs[i].PrimaryKey}
+		if job.PrimaryKey != "" {
+			job.PrimaryKeys = []string{job.PrimaryKey}
 		}
 
 		// If host is given, check to see if there is an entry in the credential map
-		config.Jobs[i].Source = imposeDefaultCredentials(
-			config.Jobs[i].Source,
+		job.Source = imposeDefaultCredentials(
+			job.Source,
 			config.CredentialDefaults,
 			defaultDriver,
 		)
 
-		for j := range config.Jobs[i].Targets {
-			config.Jobs[i].Targets[j] = imposeDefaultCredentials(
-				config.Jobs[i].Targets[j],
+		for j := range job.Targets {
+			job.Targets[j] = imposeDefaultCredentials(
+				job.Targets[j],
 				config.CredentialDefaults,
 				defaultDriver,
 			)
 		}
+
+		config.Jobs[jobName] = job // Update the map
 	}
 
 	return config, nil
@@ -135,51 +135,34 @@ func (c Config) validate() error {
 		return fmt.Errorf("no jobs found in config")
 	}
 
-	// Make sure each job name is unique
-	jobNames := map[string]int{} // name -> count
+	for name, job := range c.Jobs {
+		// Make sure every job has a non-empty name
+		if name == "" {
+			return fmt.Errorf("all jobs must have a name")
+		}
 
-	for _, job := range c.Jobs {
 		if err := job.validate(); err != nil {
-			return err
+			return fmt.Errorf("job '%s' %w", name, err)
 		}
-
-		jobNames[job.Name]++
-	}
-
-	var duplicateNames []string
-	for name, count := range jobNames {
-		if count > 1 {
-			duplicateNames = append(duplicateNames, name)
-		}
-	}
-	slices.Sort(duplicateNames) // Sort deterministically (alphabetically)
-
-	if len(duplicateNames) > 0 {
-		return fmt.Errorf("duplicate job names: %v", duplicateNames)
 	}
 
 	return nil
 }
 
 func (cfg JobConfig) validate() error {
-	// Make sure every job has a non-empty name
-	if cfg.Name == "" {
-		return fmt.Errorf("job has no name")
-	}
-
 	// Make sure primaryKeys is populated
 	if len(cfg.PrimaryKeys) == 0 {
-		return fmt.Errorf("job '%s' has no primary keys", cfg.Name)
+		return fmt.Errorf("has no primary keys")
 	}
 
 	// Make sure primaryKeys has length <= 3
 	if len(cfg.PrimaryKeys) > 3 {
-		return fmt.Errorf("job '%s' has too many primary keys", cfg.Name)
+		return fmt.Errorf("has too many primary keys")
 	}
 
 	// Make sure columns is non-empty
 	if len(cfg.Columns) == 0 {
-		return fmt.Errorf("job '%s' does not specify any columns", cfg.Name)
+		return fmt.Errorf("does not specify any columns")
 	}
 
 	// Make sure primaryKeys is a subset of columns
@@ -193,23 +176,23 @@ func (cfg JobConfig) validate() error {
 		}
 
 		if !found {
-			return fmt.Errorf("job '%s' has primary key '%s' not in columns", cfg.Name, key)
+			return fmt.Errorf("has primary key '%s' not in columns", key)
 		}
 	}
 
 	// Make sure every job has a non-empty source table
 	if err := cfg.Source.validate(); err != nil {
-		return fmt.Errorf("job '%s' source: %w", cfg.Name, err)
+		return fmt.Errorf("source: %w", err)
 	}
 
 	// Make sure every job has at least one target
 	if len(cfg.Targets) == 0 {
-		return fmt.Errorf("job '%s' has no targets", cfg.Name)
+		return fmt.Errorf("has no targets")
 	}
 
 	for i, target := range cfg.Targets {
 		if err := target.validate(); err != nil {
-			return fmt.Errorf("job '%s' target[%d]: %w", cfg.Name, i, err)
+			return fmt.Errorf("target[%d]: %w", i, err)
 		}
 	}
 

--- a/job.go
+++ b/job.go
@@ -11,16 +11,8 @@ type ExecJobResult struct {
 // ExecJob executes a single job in the sync config
 func (c Config) ExecJob(jobName string) (ExecJobResult, error) {
 	// Find the job with the given name
-	var job JobConfig
-	for _, j := range c.Jobs {
-		if j.Name == jobName {
-			job = j
-			break
-		}
-	}
-
-	// If no matching job was found, return an error
-	if job.Name == "" {
+	job, ok := c.Jobs[jobName]
+	if !ok {
 		return ExecJobResult{}, fmt.Errorf("job '%s' not found in config", jobName)
 	}
 
@@ -29,14 +21,14 @@ func (c Config) ExecJob(jobName string) (ExecJobResult, error) {
 }
 
 // ExecAllJobs executes all jobs in the sync config
-func (c Config) ExecAllJobs() ([]ExecJobResult, []error) {
-	results := make([]ExecJobResult, len(c.Jobs))
-	errors := make([]error, len(c.Jobs))
+func (c Config) ExecAllJobs() (map[string]ExecJobResult, map[string]error) {
+	results := make(map[string]ExecJobResult, len(c.Jobs))
+	errors := make(map[string]error, len(c.Jobs))
 
-	for i, job := range c.Jobs {
-		result, err := c.ExecJob(job.Name)
-		results[i] = result
-		errors[i] = err
+	for jobName := range c.Jobs {
+		result, err := c.ExecJob(jobName)
+		results[jobName] = result
+		errors[jobName] = err
 	}
 
 	return results, errors

--- a/job_test.go
+++ b/job_test.go
@@ -90,9 +90,8 @@ func TestExecJob(t *testing.T) {
 	target3.MustExec(sql, args...)
 
 	config := Config{
-		Jobs: []JobConfig{
-			{
-				Name:        "users",
+		Jobs: map[string]JobConfig{
+			"users": {
 				PrimaryKeys: []string{"id"},
 				Columns:     []string{"id", "name", "age"},
 				Source:      sourceConfig,
@@ -194,9 +193,8 @@ func TestExecJob_multiple_primary_key(t *testing.T) {
 	primaryKeys := []string{"age", "name"}
 
 	config := Config{
-		Jobs: []JobConfig{
-			{
-				Name:        "users",
+		Jobs: map[string]JobConfig{
+			"users": {
 				PrimaryKeys: primaryKeys,
 				Columns:     []string{"name", "age", "favoriteColor"},
 				Source:      sourceConfig,
@@ -356,9 +354,8 @@ func TestExecJob_mysql(t *testing.T) {
 	target3.MustExec(sql, args...)
 
 	config := Config{
-		Jobs: []JobConfig{
-			{
-				Name:        "users",
+		Jobs: map[string]JobConfig{
+			"users": {
 				PrimaryKeys: []string{"id"},
 				Columns:     []string{"id", "name", "age", "created_at"},
 				Source:      sourceConfig,
@@ -473,9 +470,8 @@ func TestExecJob_mysql_multiple_primary_key(t *testing.T) {
 	primaryKeys := []string{"age", "name"}
 
 	config := Config{
-		Jobs: []JobConfig{
-			{
-				Name:        "users",
+		Jobs: map[string]JobConfig{
+			"users": {
 				PrimaryKeys: primaryKeys,
 				Columns:     []string{"name", "age", "favoriteColor"},
 				Source:      sourceConfig,

--- a/sample_config.yaml
+++ b/sample_config.yaml
@@ -5,7 +5,7 @@ credentialDefaults:
     user: root
 
 jobs:
-  - name: users
+  users:
     columns: [id, name, age]
     source:
       table: users_source


### PR DESCRIPTION
This makes more sense, because a job must be uniquely identified by its name