### PR TITLE
General fixes and improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,8 +134,11 @@ sql-table-sync exec users pets posts
 # Exec all jobs
 sql-table-sync exec
 
-# Ping a single job
+# Ping a single job (with default 10s timeout)
 sql-table-sync ping users
+
+# Ping a single job (with custom timeout)
+sql-table-sync ping users --timeout 5s
 
 # Ping multiple jobs
 sql-table-sync ping users pets posts

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ A config file consists of two top-level sections: `defaults` (optional) and `job
 
 ### User-provided defaults
 
-The `defaults` section allows you to specify your own custom default values. These can either be global (affects all jobs) or host-specific (affects only jobs with a matching host).
+The `defaults` section allows you to specify your own custom default values. These can either be global (affects all jobs) or host-specific (affects only jobs with a matching host). You can also specify a default `source` and default `targets`.
 
 #### Global Defaults
 
@@ -190,6 +190,20 @@ In the `defaults` section, you can specify `hosts` which is a mapping of hostnam
 - `password` is the password for the database connection.
 - `port` is the port for the database connection.
 - `db` is the name of the database.
+
+#### Default Source
+
+In the `defaults` section, you can specify `source`. This specifies the default db connection parameters (DSN, host, port, etc) but does NOT include the table-- so each job must still specify a `source.table`.
+
+> [!WARNING]  
+> When using `defaults.source`, you must still specify a `source.table` for each job.
+
+#### Default Targets
+
+In the `defaults` section, you can specify `targets`. This allows you to omit the `targets` section in each job definition. This can only be used if each target table has the same name as the source table.
+
+> [!WARNING]  
+> When using `defaults.targets`, each target table must have the same name as the source table.
 
 ## Sync Algorithm
 

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"slices"
 
 	"github.com/spf13/cobra"
 
@@ -20,10 +21,14 @@ var execCmd = &cobra.Command{
 		if len(args) == 0 {
 			results, errs := config.ExecAllJobs()
 
-			first := true
+			var jobNames []string
 			for jobName := range config.Jobs {
-				if !first {
-					first = false
+				jobNames = append(jobNames, jobName)
+			}
+			slices.Sort(jobNames) // Sort the job names so the output is deterministic
+
+			for i, jobName := range jobNames {
+				if i != 0 {
 					fmt.Println() // Add a newline between job results
 				}
 

--- a/cmd/ping.go
+++ b/cmd/ping.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"slices"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -25,10 +26,14 @@ var pingCmd = &cobra.Command{
 				return
 			}
 
-			first := true
+			var jobNames []string
 			for jobName := range config.Jobs {
-				if !first {
-					first = false
+				jobNames = append(jobNames, jobName)
+			}
+			slices.Sort(jobNames) // Sort the job names so the output is deterministic
+
+			for i, jobName := range jobNames {
+				if i != 0 {
 					fmt.Println() // Add a newline between job results
 				}
 

--- a/config.go
+++ b/config.go
@@ -201,6 +201,8 @@ func loadConfig(fileContents string) (Config, error) {
 		for j := range job.Targets {
 			job.Targets[j] = imposeTableDefaults(job.Targets[j], config.Defaults)
 
+			sourceHasDSN := job.Source.DSN != ""
+			sourceHasHost := job.Source.Host != ""
 			targetHasDSN := job.Targets[j].DSN != ""
 			targetHasHost := job.Targets[j].Host != ""
 			hasDifferentDSN := job.Source.DSN != job.Targets[j].DSN

--- a/db.go
+++ b/db.go
@@ -47,7 +47,7 @@ func (t *table) connect() error {
 	var err error
 	t.DB, err = sqlx.Connect(t.config.Driver, dsn)
 	if err != nil {
-		return fmt.Errorf("failed to connect to '%s': %w", t.config.Label, err)
+		return err
 	}
 
 	t.DB.SetMaxOpenConns(5)

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.22.1
 require (
 	github.com/Masterminds/squirrel v1.5.4
 	github.com/go-sql-driver/mysql v1.8.1
-	github.com/google/go-cmp v0.6.0
 	github.com/jmoiron/sqlx v1.4.0
 	github.com/mattn/go-sqlite3 v1.14.22
 	github.com/spf13/cobra v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -7,8 +7,6 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-sql-driver/mysql v1.8.1 h1:LedoTUt/eveggdHS9qUFC1EFSa8bU2+1pZjSRpvNJ1Y=
 github.com/go-sql-driver/mysql v1.8.1/go.mod h1:wEBSXgmK//2ZFJyE+qWnIsVGmvmEKlqwuVSjsCm7DZg=
-github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
-github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/jmoiron/sqlx v1.4.0 h1:1PLqN7S1UYp5t4SrVVnt4nUVNemrDAtxlulVe+Qgm3o=

--- a/ping.go
+++ b/ping.go
@@ -49,11 +49,6 @@ func (c Config) PingJob(jobName string, timeout time.Duration) ([]PingResult, er
 		go func(j int, target TableConfig) {
 			defer wg.Done()
 
-			label := target.Label
-			if label == "" {
-				label = fmt.Sprintf("target %d", j)
-			}
-
 			resultChan <- PingResult{
 				Config: target,
 				Error:  pingWithTimeout(timeout, target, job.Columns),

--- a/sync.go
+++ b/sync.go
@@ -54,6 +54,9 @@ func (job JobConfig) syncTargets() (string, []SyncResult, error) {
 		return "", nil, err
 	}
 
+	// Close the source connection pool
+	source.Close()
+
 	sourceChecksum, err := checksumData(sourceEntries)
 	if err != nil {
 		return "", nil, err
@@ -68,6 +71,7 @@ func (job JobConfig) syncTargets() (string, []SyncResult, error) {
 			defer wg.Done()
 
 			checksum, synced, err := target.syncTarget(sourceChecksum, sourceMap)
+			target.Close() // Close the target's connection pool
 
 			resultChan <- SyncResult{
 				Target:         target.config,

--- a/sync.go
+++ b/sync.go
@@ -4,10 +4,10 @@ import (
 	"crypto/md5"
 	"encoding/hex"
 	"encoding/json"
+	"reflect"
 	"sync"
 
 	sq "github.com/Masterminds/squirrel"
-	"github.com/google/go-cmp/cmp"
 )
 
 // SyncResult contains the results of syncing a single target table
@@ -130,7 +130,7 @@ func (t table) syncTarget(
 			// Remove the key from the targetMap (to keep track of which rows we need to delete)
 			delete(targetMap, key)
 
-			if cmp.Equal(val, targetMap[key]) {
+			if reflect.DeepEqual(val, targetMap[key]) {
 				continue // No diff, so we skip this row
 			}
 


### PR DESCRIPTION
* Use `reflect.DeepEqual` instead of go-cmp `Equal`
* Default target table name to same as host
* Support for default source/targets
* Explicitly close connection pools after sync completes
* Add timeout flag to CLI's ping commands
* Print CLI output in deterministic order (was random before, due to coming from a map)
* Bug fixes